### PR TITLE
allows passing joi options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ API consumers codify their expections of your service in an executable _contract
 This project lets you write executable contracts in JavaScript. It uses [request](https://github.com/request/request) to make HTTP requests and [Joi](https://github.com/hapijs/joi) to validate API responses. Contracts are defined as JavaScript modules in a `contracts` directory at the root of your project and can be executed using the `consumer-contracts` tool.
 
 * [Getting started](#getting-started)
+* [Custom Joi options](#custom-joi-options)
 * [Anatomy of a contract](#anatomy-of-a-contract)
 * [CLI](#cli)
 
@@ -78,6 +79,22 @@ You should see that the contract validates:
 
 
 ```
+
+## Custom Joi options
+
+You could pass custom Joi options, if you want to override the defaults (have a look in lib/contract.js for them) just pass a `joiOptions` object attribute to the `options` object, like so:
+
+```js
+module.exports = new Contract({
+  name: 'User API',
+  consumer: 'My GitHub Service',
+  request: { ... },
+  response: { ... },
+  joiOptions: { ... }
+});
+```
+
+Default Joi attributes are overridden only if you specify them explicitly, otherwise they are preserved.
 
 ## Anatomy of a contract
 

--- a/lib/contract.js
+++ b/lib/contract.js
@@ -40,6 +40,9 @@ function Contract(options) {
   });
   this.before = options.before;
   this.after = options.after;
+  if (options.joiOptions) {
+    this.joiOptions = joiOptions = _.merge(joiOptions, options.joiOptions);
+  }
 }
 
 Contract.prototype.validate = function (cb) {

--- a/test/contract.js
+++ b/test/contract.js
@@ -55,6 +55,26 @@ describe('Contract', function () {
         }
       });
     }, 'Invalid contract: Missing required property [response]');
+
+    it('supports passing custom Joi options', function () {
+      var options = {
+        name: 'Name',
+        consumer: 'Consumer',
+        request: {
+          url: 'http://api.example.com/'
+        },
+        response: {
+          statusCode: 200,
+          body: Joi.object().keys({
+            foo: Joi.string()
+          })
+        }
+      };
+      options.joiOptions = { just: 'checking' };
+      var contract = new Contract(options);
+      assert.equal(contract.joiOptions.just, options.joiOptions.just);
+    });
+
   });
 
   describe('.validate', function () {


### PR DESCRIPTION
Hello and thanks for this project!

This PR allows you to pass custom joi options, like so:

```javascript
var options = {
  joiOptions: { some: 'options' },
  ...
};
var contract = new Contract(options);
```

So that they could be used internally when validating a joi schema.
Let me know what you think, I'm open to discussing / changing as required.