### PR TITLE
Enable Programatic Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,3 +291,29 @@ To run a single contract, pass a filename to the `run` command:
 ```
 consumer-contracts run ./contracts/consumer-a/contract-1.js
 ```
+
+## Programmatic Usage
+
+To validate an array of contracts programmatically, first require the `validateContracts` function:
+
+```js
+var validateContracts = require('consumer-contracts').validateContracts;
+```
+
+The `validateContracts` function can then be called with an array of contracts and a callback function which takes two arguments,
+`error` and `results`:
+
+```js
+var contracts = [
+  new Contract(...),
+  new Contract(...)
+];
+
+var handleContractValidations = function (err, res) { ... }
+
+validateContracts(contracts, handleContractValidations);
+```
+
+The `error` argument will always be null, as `consumer-contracts` will always run every contract in the array rather than failing fast, as such, error handling must deal with the `err` field of each object in the results array as detailed below.
+
+The `results` will be an array of objects with fields `contract` and `err`. The `contract` field of the result object contains the executed Contract object including any `before` and `after` fields. The `err` field contains any error that occurred when validating the specific contract. Error handling should check the `err` field of every result object is `null` before declaring the contract suite as having been run successfully.

--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 module.exports.Contract = require('./lib/contract');
 module.exports.Joi = require('joi');
+module.exports.validateContracts = require('./lib/validator')

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 module.exports.Contract = require('./lib/contract');
 module.exports.Joi = require('joi');
-module.exports.validateContracts = require('./lib/validator')
+module.exports.validateContracts = require('./lib/validator');

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -4,6 +4,7 @@ var FileHound = require('filehound');
 var path = require('path');
 var fs = require('fs');
 var formatter = require('./formatter');
+var validateContracts = require('./validator')
 
 function validateContract(contract, cb) {
   contract.validate(function (err) {
@@ -25,23 +26,7 @@ function validateFiles(files) {
     return process.exit(1);
   }
 
-  async.mapSeries(contracts, validateContract, function (err, results) {
-    var failures = _(results).filter('err').compact().value();
-    var totalCompleted = contracts.length;
-    var totalFailed = failures.length;
-    var totalPassed = totalCompleted - totalFailed;
-    var exitCode = (failures.length > 0) ? 1 : 0;
-
-    formatter.print({
-      results: results,
-      failures: failures,
-      totalCompleted: totalCompleted,
-      totalFailed: totalFailed,
-      totalPassed: totalPassed
-    });
-
-    process.exit(exitCode);
-  });
+  validateContracts(contracts);
 }
 
 module.exports = function (files) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,6 +1,8 @@
+var _ = require('lodash');
 var FileHound = require('filehound');
 var path = require('path');
 var fs = require('fs');
+var formatter = require('./formatter');
 var validateContracts = require('./validator');
 
 function validateFiles(files) {
@@ -14,7 +16,23 @@ function validateFiles(files) {
     return process.exit(1);
   }
 
-  validateContracts(contracts);
+  validateContracts(contracts, function (err, results) {
+    var failures = _(results).filter('err').compact().value();
+    var totalCompleted = contracts.length;
+    var totalFailed = failures.length;
+    var totalPassed = totalCompleted - totalFailed;
+    var exitCode = (failures.length > 0) ? 1 : 0;
+
+    formatter.print({
+      results: results,
+      failures: failures,
+      totalCompleted: totalCompleted,
+      totalFailed: totalFailed,
+      totalPassed: totalPassed
+    });
+
+    process.exit(exitCode);
+  });
 }
 
 module.exports = function (files) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,19 +1,7 @@
-var _ = require('lodash');
-var async = require('async');
 var FileHound = require('filehound');
 var path = require('path');
 var fs = require('fs');
-var formatter = require('./formatter');
-var validateContracts = require('./validator')
-
-function validateContract(contract, cb) {
-  contract.validate(function (err) {
-    cb(null, {
-      contract: contract,
-      err: err
-    });
-  });
-}
+var validateContracts = require('./validator');
 
 function validateFiles(files) {
   var contracts;

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,6 +1,4 @@
-var _ = require('lodash');
 var async = require('async');
-var formatter = require('./formatter');
 
 function validateContract(contract, cb) {
   contract.validate(function (err) {
@@ -11,22 +9,6 @@ function validateContract(contract, cb) {
   });
 }
 
-module.exports = function (contracts) {
-  async.mapSeries(contracts, validateContract, function (err, results) {
-    var failures = _(results).filter('err').compact().value();
-    var totalCompleted = contracts.length;
-    var totalFailed = failures.length;
-    var totalPassed = totalCompleted - totalFailed;
-    var exitCode = (failures.length > 0) ? 1 : 0;
-
-    formatter.print({
-      results: results,
-      failures: failures,
-      totalCompleted: totalCompleted,
-      totalFailed: totalFailed,
-      totalPassed: totalPassed
-    });
-
-    process.exit(exitCode);
-  });
+module.exports = function (contracts, cb) {
+  async.mapSeries(contracts, validateContract, cb);
 };

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,8 +1,5 @@
 var _ = require('lodash');
 var async = require('async');
-var FileHound = require('filehound');
-var path = require('path');
-var fs = require('fs');
 var formatter = require('./formatter');
 
 function validateContract(contract, cb) {
@@ -32,4 +29,4 @@ module.exports = function (contracts) {
 
     process.exit(exitCode);
   });
-}
+};

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,0 +1,35 @@
+var _ = require('lodash');
+var async = require('async');
+var FileHound = require('filehound');
+var path = require('path');
+var fs = require('fs');
+var formatter = require('./formatter');
+
+function validateContract(contract, cb) {
+  contract.validate(function (err) {
+    cb(null, {
+      contract: contract,
+      err: err
+    });
+  });
+}
+
+module.exports = function (contracts) {
+  async.mapSeries(contracts, validateContract, function (err, results) {
+    var failures = _(results).filter('err').compact().value();
+    var totalCompleted = contracts.length;
+    var totalFailed = failures.length;
+    var totalPassed = totalCompleted - totalFailed;
+    var exitCode = (failures.length > 0) ? 1 : 0;
+
+    formatter.print({
+      results: results,
+      failures: failures,
+      totalCompleted: totalCompleted,
+      totalFailed: totalFailed,
+      totalPassed: totalPassed
+    });
+
+    process.exit(exitCode);
+  });
+}


### PR DESCRIPTION
- Separates reading of files from validation of contracts
- Exposes validation of contracts for programatic usage via the new `validateContracts` function in `lib/validator.js`