### PR TITLE
Handle empty contracts

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -9,11 +9,23 @@ const fs = require('fs');
 const formatter = require('./formatter');
 const validateContracts = require('./validator');
 
+function isEmpty(obj) {
+  return Object.keys(obj).length === 0;
+}
+
+function validateFile(file) {
+  const contract = require(file);
+  if (isEmpty(contract)) {
+    throw new Error('No contract is defined.');
+  }
+  return contract;
+}
+
 function validateFiles(files) {
   let contracts;
 
   try {
-    contracts = files.map(require);
+    contracts = files.map(validateFile);
   } catch (err) {
     err.message = 'Failed to load contract: ' + err.message;
     console.error(err.stack);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -16,7 +16,7 @@ function isEmpty(obj) {
 function loadContracts(file) {
   const contract = require(file);
   if (isEmpty(contract)) {
-    throw new Error('No contract is defined.');
+    throw new Error(`No contract defined for '${file}'`);
   }
   return contract;
 }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -13,7 +13,7 @@ function isEmpty(obj) {
   return Object.keys(obj).length === 0;
 }
 
-function validateFile(file) {
+function loadContracts(file) {
   const contract = require(file);
   if (isEmpty(contract)) {
     throw new Error('No contract is defined.');
@@ -25,7 +25,7 @@ function validateFiles(files) {
   let contracts;
 
   try {
-    contracts = files.map(validateFile);
+    contracts = files.map(loadContracts);
   } catch (err) {
     err.message = 'Failed to load contract: ' + err.message;
     console.error(err.stack);


### PR DESCRIPTION
Fixes #53 

Will raise an error when a contract is empty, as contracts should always be defined. 