### PR TITLE
Add retry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,9 +303,9 @@ module.exports = new Contract({
 });
 ```
 
-### `retry` _optional_
+### `retries` _optional_
 
-Retries the contract once if it fails
+Retries the contract `retries` times if it fails on the first attempt.
 
 ```js
 module.exports = new Contract({
@@ -317,13 +317,13 @@ module.exports = new Contract({
   response: {
     // ...
   },
-  retry: true
+  retries: 2
 });
 ```
 
 ### `retryDelay` _optional_
 
-Used with `retry` to wait `retryDelay` milliseconds before retrying the contract
+Used with `retries` to wait `retryDelay` milliseconds between each retry.
 
 ```js
 module.exports = new Contract({
@@ -335,7 +335,7 @@ module.exports = new Contract({
   response: {
     // ...
   },
-  retry: true,
+  retries: 2,
   retryDelay: 3000
 });
 ```

--- a/README.md
+++ b/README.md
@@ -303,6 +303,43 @@ module.exports = new Contract({
 });
 ```
 
+### `retry` _optional_
+
+Retries the contract once if it fails
+
+```js
+module.exports = new Contract({
+  name: 'Contract name',
+  consumer: 'Consumer name',
+  request: {
+    // ...
+  },
+  response: {
+    // ...
+  },
+  retry: true
+});
+```
+
+### `retryDelay` _optional_
+
+Used with `retry` to wait `retryDelay` milliseconds before retrying the contract
+
+```js
+module.exports = new Contract({
+  name: 'Contract name',
+  consumer: 'Consumer name',
+  request: {
+    // ...
+  },
+  response: {
+    // ...
+  },
+  retry: true,
+  retryDelay: 3000
+});
+```
+
 ### Specifying multiple contracts
 
 Can be achived by returning an array of contracts.

--- a/lib/contract.js
+++ b/lib/contract.js
@@ -42,6 +42,8 @@ class Contract {
     this.consumer = options.consumer;
     this.before = options.before;
     this.after = options.after;
+    this.retry = options.retry || false;
+    this.retryDelay = options.retryDelay || 0;
 
     this._request = options.request;
     this._response = options.response;
@@ -52,9 +54,7 @@ class Contract {
       }
     });
 
-    if (options.joiOptions) {
-      this.joiOptions = _.merge(joiOptions, options.joiOptions);
-    }
+    this.joiOptions = _.merge({}, joiOptions, options.joiOptions || {});
   }
 
   validate(cb) {
@@ -65,21 +65,31 @@ class Contract {
       tasks.push(this.before);
     }
 
-    tasks.push((done) => {
-      this._client(this._request, (err, res) => {
+    const self = this;
+    function makeRequest(done, retry, retryDelay) {
+      self._client(self._request, (err, res) => {
         if (err) return done(new Error(`Request failed: ${err.message}`));
 
         debug(`${res.request.method} ${res.request.href} ${res.statusCode}`);
-
-        const result = schema.validate(res, joiOptions);
+        const result = schema.validate(res, self.joiOptions);
         if (result.error) {
-          const detail = result.error.details[0];
-          const path = detail.path;
-          return done(createError(detail, path, res));
+          if (retry) {
+            setTimeout(() => {
+              makeRequest(done);
+            }, retryDelay);
+          } else {
+            const detail = result.error.details[0];
+            const path = detail.path;
+            return done(createError(detail, path, res));
+          }
+        } else {
+          done();
         }
-
-        done();
       });
+    }
+
+    tasks.push((done) => {
+      makeRequest(done, self.retry, self.retryDelay);
     });
 
     if (this.after) {

--- a/lib/contract.js
+++ b/lib/contract.js
@@ -42,7 +42,7 @@ class Contract {
     this.consumer = options.consumer;
     this.before = options.before;
     this.after = options.after;
-    this.retry = options.retry || false;
+    this.retries = options.retries || 0;
     this.retryDelay = options.retryDelay || 0;
 
     this._request = options.request;
@@ -66,16 +66,16 @@ class Contract {
     }
 
     const self = this;
-    function makeRequest(done, retry, retryDelay) {
+    function makeRequest(done, retries, retryDelay) {
       self._client(self._request, (err, res) => {
         if (err) return done(new Error(`Request failed: ${err.message}`));
 
         debug(`${res.request.method} ${res.request.href} ${res.statusCode}`);
         const result = schema.validate(res, self.joiOptions);
         if (result.error) {
-          if (retry) {
+          if (retries > 0) {
             setTimeout(() => {
-              makeRequest(done);
+              makeRequest(done, --retries, retryDelay);
             }, retryDelay);
           } else {
             const detail = result.error.details[0];
@@ -89,7 +89,7 @@ class Contract {
     }
 
     tasks.push((done) => {
-      makeRequest(done, self.retry, self.retryDelay);
+      makeRequest(done, self.retries, self.retryDelay);
     });
 
     if (this.after) {

--- a/test/contract.js
+++ b/test/contract.js
@@ -336,5 +336,129 @@ describe('Contract', () => {
         done();
       });
     });
+
+    describe('Retry option on', () => {
+      it('does not return an error when the contract is invalid on the first attempt but valid on the second attempt', (done) => {
+        const responses = [
+          [500, {}],
+          [200, { bar: 'baz' }]
+        ];
+        let replyCount = 0;
+        nock('http://api.example.com').get('/').times(2).reply(() => {
+          replyCount++;
+          return responses.shift();
+        });
+
+        const contract = new Contract({
+          name: 'Name',
+          consumer: 'Consumer',
+          request: {
+            url: 'http://api.example.com/'
+          },
+          retry: true,
+          retryDelay: 0,
+          response: {
+            statusCode: 200,
+            body: Joi.object().keys({
+              bar: Joi.string()
+            })
+          }
+        });
+
+        contract.validate((err) => {
+          assert.ifError(err);
+          assert.equal(replyCount, 2);
+          done();
+        });
+      });
+
+      it('returns an error when the contract is invalid on both first and second attempts', (done) => {
+        const responses = [
+          [500, {}],
+          [500, {}]
+        ];
+        let replyCount = 0;
+        nock('http://api.example.com').get('/').times(2).reply(() => {
+          replyCount++;
+          return responses.shift();
+        });
+
+        const contract = new Contract({
+          name: 'Name',
+          consumer: 'Consumer',
+          request: {
+            url: 'http://api.example.com/'
+          },
+          retry: true,
+          retryDelay: 0,
+          response: {
+            statusCode: 200,
+            body: Joi.object().keys({
+              bar: Joi.string()
+            })
+          }
+        });
+
+        contract.validate((err) => {
+          assert.equal(replyCount, 2);
+          assert.ok(err);
+          assert.equal(err.message, 'Contract failed: "statusCode" must be [200]');
+          assert.equal(err.detail, 'at res.statusCode got [500]');
+          done();
+        });
+      });
+
+      it('waits before retrying if the retryDelay is specified', (done) => {
+
+        const mockClient = sinon.stub();
+        mockClient.defaults = () => {};
+        mockClient.onFirstCall().yields(undefined, {
+          statusCode: 500,
+          request: {},
+          body: {}
+        });
+
+        mockClient.onSecondCall().yields(undefined, {
+          statusCode: 200,
+          request: {},
+          body: { bar: 'baz' }
+        });
+
+        const client = {
+          defaults: () => mockClient
+        };
+
+        const clock = sinon.useFakeTimers();
+
+        const contract = new Contract({
+          name: 'Name',
+          consumer: 'Consumer',
+          request: {
+            url: 'http://api.example.com/'
+          },
+          client,
+          retry: true,
+          retryDelay: 2000,
+          response: {
+            statusCode: 200,
+            body: Joi.object().keys({
+              bar: Joi.string()
+            })
+          }
+        });
+
+        contract.validate((err) => {
+          assert.ifError(err);
+          assert.equal(mockClient.callCount, 2);
+          done();
+        });
+
+        assert.equal(mockClient.callCount, 1);
+        clock.tick(2000);
+        assert.equal(mockClient.callCount, 2);
+        clock.restore();
+      });
+    });
+
   });
 });


### PR DESCRIPTION
## Description
Add options to retry a contract test with an (optional) delay

## Motivation and Context
To make contract tests work that query endpoints that need to be warmed up after a deployment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
