### PR TITLE
feat: default client now no longer follows redirects like previous behaviour

### DIFF
--- a/lib/contract.ts
+++ b/lib/contract.ts
@@ -178,7 +178,8 @@ export class Contract {
       const httpTransportClient = builder.createClient()
         .timeout(this._requestOptions.timeout || 0)
         .headers(this._requestOptions.headers || {})
-        .query(this._requestOptions.query || {});
+        .query(this._requestOptions.query || {})
+        .redirect('manual');
 
       this._client = async function (request: ContractRequest) {
         return (<any>httpTransportClient)[(this._request.method || "get").toLowerCase()](request.url, request.body).asResponse();


### PR DESCRIPTION
## Description

Updated default clients transport to no longer follow redirects as per previous behaviour.

IPLAYER-43811

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
