### PR TITLE
feat: adding function based retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,16 +350,34 @@ module.exports = new Contract({
 Retries the contract if it fails. Can be specified in two ways:
 
 1. As a number - will retry that many times with optional fixed delay:
+
 ```js
-{
+module.exports = new Contract({
+  name: "Contract name",
+  consumer: "Consumer name",
+  request: {
+    // ...
+  },
+  response: {
+    // ...
+  },
   retries: 2,
   retryDelay: 3000 // optional, milliseconds between retries
-}
+});
 ```
 
 2. As an object with custom retry logic:
+
 ```js
-{
+module.exports = new Contract({
+  name: "Contract name",
+  consumer: "Consumer name",
+  request: {
+    // ...
+  },
+  response: {
+    // ...
+  },
   retries: {
     maxRetries: 3,
     handler: (error, request, retryCount) => {
@@ -374,7 +392,7 @@ Retries the contract if it fails. Can be specified in two ways:
       return false;
     }
   }
-}
+});
 ```
 
 The retry handler receives:

--- a/lib/contract.ts
+++ b/lib/contract.ts
@@ -316,7 +316,7 @@ export class Contract {
       return;
     }
 
-    if (this.after) {
+    if (!validationError && this.after) {
       if (this.after.constructor.name === 'AsyncFunction') {
         // Promise-based after
         assertIsAsyncBeforeAfter(this.after);

--- a/lib/contract.ts
+++ b/lib/contract.ts
@@ -316,7 +316,7 @@ export class Contract {
       return;
     }
 
-    if (!validationError && this.after) {
+    if (this.after) {
       if (this.after.constructor.name === 'AsyncFunction') {
         // Promise-based after
         assertIsAsyncBeforeAfter(this.after);

--- a/lib/contract.ts
+++ b/lib/contract.ts
@@ -312,9 +312,11 @@ export class Contract {
       }
     } catch (error) {
       validationError = error;
+      callback(error, undefined);
+      return;
     }
 
-    if (this.after) {
+    if (!validationError && this.after) {
       if (this.after.constructor.name === 'AsyncFunction') {
         // Promise-based after
         assertIsAsyncBeforeAfter(this.after);

--- a/test/contract.ts
+++ b/test/contract.ts
@@ -408,6 +408,29 @@ describe("Contract", () => {
       });
     });
 
+    it("does not call after function when there are validation errors", async () => {
+      const after = sinon.stub().yields();
+
+      nock("http://api.example.com").get("/").reply(500);
+
+      const contract = new Contract({
+        name: "Name",
+        consumer: "Consumer",
+        request: {
+          url: "http://api.example.com/",
+        },
+        response: {
+          status: 200,
+        },
+        after,
+      });
+
+      return contract.validate((err) => {
+        assert.ok(err);
+        assert.equal(err.message, 'Contract failed: "status" must be [200]');
+        sinon.assert.notCalled(after);
+      });
+    });
 
     it("applies any custom Joi options", async () => {
       nock("http://api.example.com").get("/").reply(200, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This allows users to configure retry functionality with logic rather than arbitrary numbers, they can now provide an object with the maximum number of retries and a handler.

The handler will be passed the validationError, the request details and the retryCount.

It can use this information to determine if a test should be retried or not and even implement exponential backoff.

To enable this, some other code and documentation has also been adjusted. This should be backwards compatible though.

## Motivation and Context

In the Experimentation team at the BBC, we are using Consumer Contracts to validate the responses of APIs on a daily basis, some of the APIs we need to validate against initially return 202 Accepted status codes alongside a retry time header, we need to keep retrying those APIs until they respond with a 200.

With the current retries functionality, we can only do this on the basis of always retrying, no matter the status code and also, we cannot use exponential backoff at the moment, this is quite wasteful and could make tests run much longer than they need to.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
